### PR TITLE
[encoder_audio_ac3] 0.0.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.7</span>**
+- fix stray character in custom stream mapping function
+
 **<span style="color:#56adda">0.0.6</span>**
 - add an '-ac` parameter to encoder to avoid unsupported channel layout error when normalizing 6 channel streams
 

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.6"
+    "version": "0.0.7"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -170,7 +170,7 @@ class PluginStreamMapper(StreamMapper):
             if stream_info.get('channels'):
                 # Use 64K for the bitrate per channel
                 calculated_bitrate = self.calculate_bitrate(stream_info)
-                channels = int()stream_info.get('channels'))
+                channels = int(stream_info.get('channels'))
                 stream_encoding += [
                     '-ac:a:{}'.format(stream_id), '{}'.format(channels), '-b:a:{}'.format(stream_id), "{}k".format(calculated_bitrate)
                 ]


### PR DESCRIPTION
fixed stray character in custom stream mapping routine.