### PR TITLE
[encoder_audio_ac3] 0.0.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.7</span>**
+- add check in calculate_bitrate and custom_stream_mapping to set channels to 6 if channels > 6.  ffmpeg cannot encode > 6 channels of ac3 audio. 
+
 **<span style="color:#56adda">0.0.6</span>**
 - add an '-ac` parameter to encoder to avoid unsupported channel layout error when normalizing 6 channel streams
 

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.6"
+    "version": "0.0.7"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -139,6 +139,8 @@ class PluginStreamMapper(StreamMapper):
             logger.debug("Stream did not contain 'channels'. Setting max AC3 bit rate (640k).")
             return '640'
 
+        if int(channels) > 6:
+            channels = 6
         # Determine bitrate based on source channel count
         if int(channels) <= 2:
             logger.debug("Stream 'channels' is <= 2. Setting AC3 bit rate to 448k.")
@@ -171,6 +173,8 @@ class PluginStreamMapper(StreamMapper):
                 # Use 64K for the bitrate per channel
                 calculated_bitrate = self.calculate_bitrate(stream_info)
                 channels = int()stream_info.get('channels'))
+                if int(channels) > 6:
+                    channels = 6
                 stream_encoding += [
                     '-ac:a:{}'.format(stream_id), '{}'.format(channels), '-b:a:{}'.format(stream_id), "{}k".format(calculated_bitrate)
                 ]


### PR DESCRIPTION
In cases where user's source has > 6 audio channels in a stream, set the channels to 6 since ffmpeg cannot encode > 6 channels using ac3 encoder. Made fix in both custom_stream_mapping and calculate_bit_rate, the latter so that the total bit rate for is a function of 6 channels and not of > 6 channels